### PR TITLE
Set constants in constructor instead of public fields in development.js

### DIFF
--- a/lib/development.js
+++ b/lib/development.js
@@ -6,9 +6,6 @@ import {dequal} from 'dequal'
 const codesWarned = new Set()
 
 class AssertionError extends Error {
-  name = /** @type {const} */ ('Assertion')
-  code = /** @type {const} */ ('ERR_ASSERTION')
-
   /**
    * Create an assertion error.
    *
@@ -52,12 +49,12 @@ class AssertionError extends Error {
      * @type {string}
      */
     this.operator = operator
+    this.name = 'Assertion'
+    this.code = 'ERR_ASSERTION'
   }
 }
 
 class DeprecationError extends Error {
-  name = /** @type {const} */ ('DeprecationWarning')
-
   /**
    * Create a deprecation message.
    *
@@ -75,6 +72,7 @@ class DeprecationError extends Error {
      * @type {string | undefined}
      */
     this.code = code
+    this.name = 'DeprecationWarning'
   }
 }
 


### PR DESCRIPTION
In `development.js`, public class fields are currently used, which are unsupported by approximately 7% of devices in 2024 (source: [Can I use...](https://caniuse.com/mdn-javascript_classes_public_class_fields)).

While development typically targets modern browsers, older browsers might still be used during e2e testing. For example, Safari 13 and similar browsers do not support public class fields, which can cause issues in your app.

This PR makes a small adjustment to replace public class fields with a more widely supported alternative. This change does not impact functionality but enhances compatibility across a broader range of browsers.
